### PR TITLE
Fix an issue for non-example files

### DIFF
--- a/src/pfs_blackout_design/MaskedPfsDesign.py
+++ b/src/pfs_blackout_design/MaskedPfsDesign.py
@@ -203,11 +203,3 @@ class MaskedPfsDesign:
     def do_all(self):
         self._mask_entries()
         self._write_designs()
-
-
-masked_pfs_design = MaskedPfsDesign(
-    "pfsDesign-0x4f966fa98c958b91.fits",
-    indir="./tmp/examples/",
-    outdir="./tmp/examples/",
-    is_file=True,
-)


### PR DESCRIPTION
For some reason, unnecessary lines were inserted in MaskedPfsDesign.py, forcing to use an example file and directories. These lines are simpley removed and it works for general files. I still don't understand why the piece of code was inserted. Maybe editor's fault or my fault on the copy and paste. Anyway, thank Mao-san for testing.