### PR TITLE
Fix an issue when all fibers have the same proposal ID

### DIFF
--- a/src/pfs_blackout_design/MaskedPfsDesign.py
+++ b/src/pfs_blackout_design/MaskedPfsDesign.py
@@ -198,7 +198,7 @@ class MaskedPfsDesign:
                     ]
                     getattr(design_tmp, "filterNames")[i] = filter_mask
 
-                    self.out_designs[propid_use] = design_tmp
+            self.out_designs[propid_use] = design_tmp
 
     def do_all(self):
         self._mask_entries()


### PR DESCRIPTION
Due to my fault the masked output is not generated when all fibers have an identical proposal ID. It's just an indentation issue. I hope the commit fixed it.